### PR TITLE
Add proper process.exit call

### DIFF
--- a/iothub-diagnostics.js
+++ b/iothub-diagnostics.js
@@ -38,4 +38,6 @@ async.series([
       require('./iothubtests').run(process.argv[2], done);
     }
   }
-]);
+], function () {
+  process.exit(0);
+});


### PR DESCRIPTION
# Description of the problem
Looks like we now need an explicit call to process.exit() to properly terminate

# Description of the solution
add a call to process.exit() in the last callback.
